### PR TITLE
add: ability to access localhost over http

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
Hi, I really love eruda and this browser makes it super nice to use :) I was trying to debug something running from a local webserver on my phone and I ran into an error trying to access localhost which is described [here](https://stackoverflow.com/questions/59116787/failed-to-load-resource-neterr-cleartext-not-permitted). This change makes it so that the app can access sites over http so it fixes my problem. Given that this is a browser that will really only be used by developers I think we are safe to enable http here :) I can't read it but it seems like this will fix #12 

thanks for taking a look!